### PR TITLE
Fix text segment size logging

### DIFF
--- a/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
+++ b/langchain4j-core/src/main/java/dev/langchain4j/store/embedding/EmbeddingStoreIngestor.java
@@ -195,7 +195,7 @@ public class EmbeddingStoreIngestor {
         }
         if (textSegmentTransformer != null) {
             segments = textSegmentTransformer.transformAll(segments);
-            log.debug("Text segments were transformed into {} text segments", documents.size());
+            log.debug("Text segments were transformed into {} text segments", segments.size());
         }
 
         // TODO handle failures, parallelize


### PR DESCRIPTION
## Summary
- fix log statement to use segments size after transformation

## Testing
- `./mvnw -q -pl langchain4j-core -Dgib.disable=true test` *(fails: Plugin com.vackosar.gitflowincrementalbuilder could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_683fe0c2c1a88327b350a146a22f8e9d